### PR TITLE
Removed the version restriction on scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         'pandas>=0.20.2',
         'numpy>=1.9.2',
-        'scikit-learn>=0.16.0,<=0.24',
+        'scikit-learn>=0.16.0',
         'scipy>=1.0.1',
         'future>=0.16.0'
     ],


### PR DESCRIPTION
It looks like the library doesn't have a hard restriction on the version of scikit-learn, so I removed the version restriction